### PR TITLE
Add repository entry to package.json for easier lookup on npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "description": "Change Feed Modules",
   "version": "1.1.9",
   "author": "Joyent (joyent.com)",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/joyent/node-sdc-changefeed.git"
+  },
   "private": false,
   "main": "./lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Every time I go the [the changefeed page on npmjs.org](https://www.npmjs.com/package/changefeed) and I want to look at the source, I can't find its source repository and I end up searching for "changefeed" in the [Joyent GitHub organization page](https://github.com/joyent/).

Adding the repository entry to package.json should fix that.